### PR TITLE
Use activate instead of start for controllers because this is new nomenclature used in ros2_control.

### DIFF
--- a/ur_simulation_ignition/launch/ur_sim_control.launch.py
+++ b/ur_simulation_ignition/launch/ur_sim_control.launch.py
@@ -56,7 +56,7 @@ def launch_setup(context, *args, **kwargs):
     description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
     prefix = LaunchConfiguration("prefix")
-    start_joint_controller = LaunchConfiguration("start_joint_controller")
+    activate_joint_controller = LaunchConfiguration("activate_joint_controller")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     launch_rviz = LaunchConfiguration("launch_rviz")
 
@@ -129,7 +129,8 @@ def launch_setup(context, *args, **kwargs):
         event_handler=OnProcessExit(
             target_action=joint_state_broadcaster_spawner,
             on_exit=[rviz_node],
-        )
+        ),
+        condition=IfCondition(launch_rviz),
     )
 
     # There may be other controllers of the joints, but this is the initially-started one
@@ -137,13 +138,13 @@ def launch_setup(context, *args, **kwargs):
         package="controller_manager",
         executable="spawner",
         arguments=[initial_joint_controller, "-c", "/controller_manager"],
-        condition=IfCondition(start_joint_controller),
+        condition=IfCondition(activate_joint_controller),
     )
     initial_joint_controller_spawner_stopped = Node(
         package="controller_manager",
         executable="spawner",
         arguments=[initial_joint_controller, "-c", "/controller_manager", "--stopped"],
-        condition=UnlessCondition(start_joint_controller),
+        condition=UnlessCondition(activate_joint_controller),
     )
 
     # Ignition nodes
@@ -255,7 +256,7 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "start_joint_controller",
+            "activate_joint_controller",
             default_value="true",
             description="Enable headless mode for robot control",
         )


### PR DESCRIPTION
Clearer naming of launch-file argument and adding check for conditional rviz start.
