### PR TITLE
use tf_prefix instead of prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,25 @@ Example using MoveIt with simulated robot:
 ```
 ros2 launch ur_simulation_gz ur_sim_moveit.launch.py
 ```
+
+
+## Using a custom tf_prefix
+
+In case you would like to use a custom prefix to your simulated robot, you can provide one by
+passing the `tf_prefix` to the control launchfile:
+
+``` bash
+ros2 launch ur_simulation_gz ur_sim_control.launch.py tf_prefix:=my_ur_
+```
+
+However, when doing so, you will have to provide your own controller configuration file. A
+corresponding file to the prefix above could look as in [this example](ur_simulation_gz/config/my_ur_controllers.yaml).
+
+Therefore, the following would work:
+```bash
+ros2 launch ur_simulation_gz ur_sim_control.launch.py tf_prefix:=my_ur_ \
+  controllers_file:=my_ur_controllers.yaml
+```
+
+Using the `$(var tf_prefix)` notation as in the driver does not work here, since the file is loaded
+differently, where (to our knowledge) no variable substitution is possible.

--- a/ur_simulation_gz/config/my_ur_controllers.yaml
+++ b/ur_simulation_gz/config/my_ur_controllers.yaml
@@ -1,0 +1,87 @@
+controller_manager:
+  ros__parameters:
+    update_rate: 500  # Hz
+
+    joint_state_broadcaster:
+      type: joint_state_broadcaster/JointStateBroadcaster
+
+    force_torque_sensor_broadcaster:
+      type: ur_controllers/ForceTorqueStateBroadcaster
+
+    joint_trajectory_controller:
+      type: joint_trajectory_controller/JointTrajectoryController
+
+    forward_velocity_controller:
+      type: velocity_controllers/JointGroupVelocityController
+
+    forward_position_controller:
+      type: position_controllers/JointGroupPositionController
+
+
+speed_scaling_state_broadcaster:
+  ros__parameters:
+    state_publish_rate: 100.0
+    tf_prefix: "my_ur_"
+
+
+force_torque_sensor_broadcaster:
+  ros__parameters:
+    sensor_name: my_ur_tcp_fts_sensor
+    state_interface_names:
+      - force.x
+      - force.y
+      - force.z
+      - torque.x
+      - torque.y
+      - torque.z
+    frame_id: tool0
+    topic_name: ft_data
+
+
+joint_trajectory_controller:
+  ros__parameters:
+    joints:
+      - my_ur_shoulder_pan_joint
+      - my_ur_shoulder_lift_joint
+      - my_ur_elbow_joint
+      - my_ur_wrist_1_joint
+      - my_ur_wrist_2_joint
+      - my_ur_wrist_3_joint
+    command_interfaces:
+      - position
+    state_interfaces:
+      - position
+      - velocity
+    state_publish_rate: 100.0
+    action_monitor_rate: 20.0
+    allow_partial_joints_goal: false
+    constraints:
+      stopped_velocity_tolerance: 0.2
+      goal_time: 0.0
+      my_ur_shoulder_pan_joint: {trajectory: 0.2, goal: 0.1}
+      my_ur_shoulder_lift_joint: {trajectory: 0.2, goal: 0.1}
+      my_ur_elbow_joint: {trajectory: 0.2, goal: 0.1}
+      my_ur_wrist_1_joint: {trajectory: 0.2, goal: 0.1}
+      my_ur_wrist_2_joint: {trajectory: 0.2, goal: 0.1}
+      my_ur_wrist_3_joint: {trajectory: 0.2, goal: 0.1}
+
+forward_velocity_controller:
+  ros__parameters:
+    joints:
+      - my_ur_shoulder_pan_joint
+      - my_ur_shoulder_lift_joint
+      - my_ur_elbow_joint
+      - my_ur_wrist_1_joint
+      - my_ur_wrist_2_joint
+      - my_ur_wrist_3_joint
+    interface_name: velocity
+
+forward_position_controller:
+  ros__parameters:
+    joints:
+      - my_ur_shoulder_pan_joint
+      - my_ur_shoulder_lift_joint
+      - my_ur_elbow_joint
+      - my_ur_wrist_1_joint
+      - my_ur_wrist_2_joint
+      - my_ur_wrist_3_joint

--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -54,7 +54,7 @@ def launch_setup(context, *args, **kwargs):
     controllers_file = LaunchConfiguration("controllers_file")
     description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
-    prefix = LaunchConfiguration("prefix")
+    tf_prefix = LaunchConfiguration("tf_prefix")
     start_joint_controller = LaunchConfiguration("start_joint_controller")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     launch_rviz = LaunchConfiguration("launch_rviz")
@@ -90,8 +90,8 @@ def launch_setup(context, *args, **kwargs):
             "ur_type:=",
             ur_type,
             " ",
-            "prefix:=",
-            prefix,
+            "tf_prefix:=",
+            tf_prefix,
             " ",
             "sim_ignition:=true",
             " ",
@@ -245,9 +245,9 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "prefix",
+            "tf_prefix",
             default_value='""',
-            description="Prefix of the joint names, useful for \
+            description="tf_prefix of the joint names, useful for \
         multi-robot setup. If changed than also joint names in the controllers' configuration \
         have to be updated.",
         )


### PR DESCRIPTION
This changes the `prefix` parameter to `tf_prefix` as needed by the URDF.

Note: Currently you will need to provide your own controller configuration containing the prefixed joint names. This needs to be documented, hence the draft status.

Fixes #19 