### PR TITLE
Migrate from ignition to gz internally

### DIFF
--- a/ur_simulation_gz.iron.repos
+++ b/ur_simulation_gz.iron.repos
@@ -1,8 +1,8 @@
 repositories:
   gz_ros2_control:
     type: git
-    url: https://github.com/ignitionrobotics/gz_ros2_control.git
-    version: master
+    url: https://github.com/ros-controls/gz_ros2_control.git
+    version: iron
   ros_gz:
     type: git
     url: https://github.com/gazebosim/ros_gz

--- a/ur_simulation_gz.rolling.repos
+++ b/ur_simulation_gz.rolling.repos
@@ -3,10 +3,6 @@ repositories:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
     version: master
-  ros_ign:
-    type: git
-    url: https://github.com/ignitionrobotics/ros_ign.git
-    version: ros2
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2.git

--- a/ur_simulation_gz/package.xml
+++ b/ur_simulation_gz/package.xml
@@ -12,8 +12,8 @@
 
   <license>BSD-3-Clause</license>
 
-  <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_Ignition_Simulation/issues</url>
-  <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_Ignition_Simulation</url>
+  <url type="bugtracker">https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues</url>
+  <url type="repository">https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 


### PR DESCRIPTION
The old repo name was referenced in the package.xml and somme upstream URLs were pointing to old locations.