### PR TITLE
Update for new ur_moveit_config 

### DIFF
--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -44,8 +44,7 @@ def launch_setup(context, *args, **kwargs):
     controllers_file = LaunchConfiguration("controllers_file")
     description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
-    moveit_config_package = LaunchConfiguration("moveit_config_package")
-    moveit_config_file = LaunchConfiguration("moveit_config_file")
+    moveit_launch_file = LaunchConfiguration("moveit_launch_file")
     prefix = LaunchConfiguration("prefix")
 
     ur_control_launch = IncludeLaunchDescription(
@@ -66,16 +65,10 @@ def launch_setup(context, *args, **kwargs):
 
     ur_moveit_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [FindPackageShare("ur_moveit_config"), "/launch", "/ur_moveit.launch.py"]
+            moveit_launch_file
         ),
         launch_arguments={
             "ur_type": ur_type,
-            "safety_limits": safety_limits,
-            "description_package": description_package,
-            "description_file": description_file,
-            "moveit_config_package": moveit_config_package,
-            "moveit_config_file": moveit_config_file,
-            "prefix": prefix,
             "use_sim_time": "true",
             "launch_rviz": "true",
         }.items(),
@@ -140,17 +133,14 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "moveit_config_package",
-            default_value="ur_moveit_config",
-            description="MoveIt config package with robot SRDF/XACRO files. Usually the argument "
+            "moveit_launch_file",
+            default_value=[
+                FindPackageShare("ur_moveit_config"),
+                "/launch",
+                "/ur_moveit.launch.py",
+            ],
+            description="Absolute path for MoveIt launch file, part of a config package with robot SRDF/XACRO files. Usually the argument "
             "is not set, it enables use of a custom moveit config.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "moveit_config_file",
-            default_value="ur.srdf.xacro",
-            description="MoveIt SRDF/XACRO description file with the robot.",
         )
     )
     declared_arguments.append(

--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -31,7 +31,7 @@
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription, OpaqueFunction
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.substitutions import FindPackageShare
 
 
@@ -49,7 +49,9 @@ def launch_setup(context, *args, **kwargs):
 
     ur_control_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
-            [FindPackageShare("ur_simulation_gz"), "/launch", "/ur_sim_control.launch.py"]
+            PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "launch", "ur_sim_control.launch.py"]
+            )
         ),
         launch_arguments={
             "ur_type": ur_type,
@@ -132,11 +134,13 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "moveit_launch_file",
-            default_value=[
-                FindPackageShare("ur_moveit_config"),
-                "/launch",
-                "/ur_moveit.launch.py",
-            ],
+            default_value=PathJoinSubstitution(
+                [
+                    FindPackageShare("ur_moveit_config"),
+                    "launch",
+                    "ur_moveit.launch.py",
+                ]
+            ),
             description="Absolute path for MoveIt launch file, part of a config package with robot SRDF/XACRO files. Usually the argument "
             "is not set, it enables use of a custom moveit config.",
         )

--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -64,9 +64,7 @@ def launch_setup(context, *args, **kwargs):
     )
 
     ur_moveit_launch = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource(
-            moveit_launch_file
-        ),
+        PythonLaunchDescriptionSource(moveit_launch_file),
         launch_arguments={
             "ur_type": ur_type,
             "use_sim_time": "true",


### PR DESCRIPTION
This PR removes arguments like `moveit_config_package` and `moveit_config_file` in favor of receiving the absolute path of a launch file (`moveit_launch_file`) for moveit when a custom moveit config has to be used. Removing in a similar way `description_pkg` (as requested in [#22](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/22)) will be done in a different PR. 
It requires [#998](https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/998) to be tested.