### PR TITLE
Migrating to absolute paths

### DIFF
--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -63,14 +63,11 @@ def launch_setup(context, *args, **kwargs):
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     description_file = LaunchConfiguration("description_file")
     launch_rviz = LaunchConfiguration("launch_rviz")
+    rviz_config_file = LaunchConfiguration("rviz_config_file")
     gazebo_gui = LaunchConfiguration("gazebo_gui")
 
     initial_joint_controllers = PathJoinSubstitution(
         [FindPackageShare(runtime_config_package), "config", controllers_file]
-    )
-
-    rviz_config_file = PathJoinSubstitution(
-        [FindPackageShare("ur_description"), "rviz", "view_robot.rviz"]
     )
 
     robot_description_content = Command(
@@ -269,6 +266,15 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?")
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "rviz_config_file",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_description"), "rviz", "view_robot.rviz"]
+            ),
+            description="Rviz config file (absolute path) to use when launching rviz.",
+        )
     )
     declared_arguments.append(
         DeclareLaunchArgument(

--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -61,6 +61,7 @@ def launch_setup(context, *args, **kwargs):
     prefix = LaunchConfiguration("prefix")
     activate_joint_controller = LaunchConfiguration("activate_joint_controller")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
+    description_file = LaunchConfiguration("description_file")
     launch_rviz = LaunchConfiguration("launch_rviz")
     gazebo_gui = LaunchConfiguration("gazebo_gui")
 
@@ -76,9 +77,7 @@ def launch_setup(context, *args, **kwargs):
         [
             PathJoinSubstitution([FindExecutable(name="xacro")]),
             " ",
-            PathJoinSubstitution(
-                [FindPackageShare("ur_simulation_gz"), "urdf", "ur_gz.urdf.xacro"]
-            ),
+            description_file,
             " ",
             "safety_limits:=",
             safety_limits,
@@ -257,6 +256,15 @@ def generate_launch_description():
             "initial_joint_controller",
             default_value="joint_trajectory_controller",
             description="Robot controller to start.",
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "description_file",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "urdf", "ur_gz.urdf.xacro"]
+            ),
+            description="URDF/XACRO description file (absolute path) with the robot.",
         )
     )
     declared_arguments.append(

--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -42,7 +42,6 @@ def launch_setup(context, *args, **kwargs):
     # General arguments
     runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
-    description_package = LaunchConfiguration("description_package")
     description_file = LaunchConfiguration("description_file")
     moveit_launch_file = LaunchConfiguration("moveit_launch_file")
     prefix = LaunchConfiguration("prefix")
@@ -58,7 +57,6 @@ def launch_setup(context, *args, **kwargs):
             "safety_limits": safety_limits,
             "runtime_config_package": runtime_config_package,
             "controllers_file": controllers_file,
-            "description_package": description_package,
             "description_file": description_file,
             "prefix": prefix,
             "launch_rviz": "false",
@@ -118,17 +116,11 @@ def generate_launch_description():
     )
     declared_arguments.append(
         DeclareLaunchArgument(
-            "description_package",
-            default_value="ur_description",
-            description="Description package with robot URDF/XACRO files. Usually the argument "
-            "is not set, it enables use of a custom description.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
             "description_file",
-            default_value="ur.urdf.xacro",
-            description="URDF/XACRO description file with the robot.",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "urdf", "ur_gz.urdf.xacro"]
+            ),
+            description="URDF/XACRO description file (absolute path) with the robot.",
         )
     )
     declared_arguments.append(


### PR DESCRIPTION
This PR restructures launch files in order to remove the previous "description_package" + "description_file" combination in favor of a nicer absolute path definition in "description_file" only, as requested in [#22](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/22).