### PR TITLE
Added absolute path for controllers file

### DIFF
--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -56,7 +56,6 @@ def launch_setup(context, *args, **kwargs):
     safety_pos_margin = LaunchConfiguration("safety_pos_margin")
     safety_k_position = LaunchConfiguration("safety_k_position")
     # General arguments
-    runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
     tf_prefix = LaunchConfiguration("tf_prefix")
     activate_joint_controller = LaunchConfiguration("activate_joint_controller")
@@ -65,10 +64,6 @@ def launch_setup(context, *args, **kwargs):
     launch_rviz = LaunchConfiguration("launch_rviz")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
     gazebo_gui = LaunchConfiguration("gazebo_gui")
-
-    initial_joint_controllers = PathJoinSubstitution(
-        [FindPackageShare(runtime_config_package), "config", controllers_file]
-    )
 
     robot_description_content = Command(
         [
@@ -95,7 +90,7 @@ def launch_setup(context, *args, **kwargs):
             tf_prefix,
             " ",
             "simulation_controllers:=",
-            initial_joint_controllers,
+            controllers_file,
         ]
     )
     robot_description = {"robot_description": robot_description_content}
@@ -219,17 +214,11 @@ def generate_launch_description():
     # General arguments
     declared_arguments.append(
         DeclareLaunchArgument(
-            "runtime_config_package",
-            default_value="ur_simulation_gz",
-            description='Package with the controller\'s configuration in "config" folder. '
-            "Usually the argument is not set, it enables use of a custom setup.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
             "controllers_file",
-            default_value="ur_controllers.yaml",
-            description="YAML file with the controllers configuration.",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "config", "ur_controllers.yaml"]
+            ),
+            description="Absolute path to YAML file with the controllers configuration.",
         )
     )
     declared_arguments.append(

--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -43,7 +43,6 @@ def launch_setup(context, *args, **kwargs):
     controllers_file = LaunchConfiguration("controllers_file")
     description_file = LaunchConfiguration("description_file")
     moveit_launch_file = LaunchConfiguration("moveit_launch_file")
-    prefix = LaunchConfiguration("prefix")
 
     ur_control_launch = IncludeLaunchDescription(
         PythonLaunchDescriptionSource(
@@ -56,7 +55,6 @@ def launch_setup(context, *args, **kwargs):
             "safety_limits": safety_limits,
             "controllers_file": controllers_file,
             "description_file": description_file,
-            "tf_prefix": prefix,
             "launch_rviz": "false",
         }.items(),
     )
@@ -127,15 +125,6 @@ def generate_launch_description():
             ),
             description="Absolute path for MoveIt launch file, part of a config package with robot SRDF/XACRO files. Usually the argument "
             "is not set, it enables use of a custom moveit config.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
-            "prefix",
-            default_value='""',
-            description="Prefix of the joint names, useful for "
-            "multi-robot setup. If changed than also joint names in the controllers' configuration "
-            "have to be updated.",
         )
     )
 

--- a/ur_simulation_gz/launch/ur_sim_moveit.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_moveit.launch.py
@@ -40,7 +40,6 @@ def launch_setup(context, *args, **kwargs):
     ur_type = LaunchConfiguration("ur_type")
     safety_limits = LaunchConfiguration("safety_limits")
     # General arguments
-    runtime_config_package = LaunchConfiguration("runtime_config_package")
     controllers_file = LaunchConfiguration("controllers_file")
     description_file = LaunchConfiguration("description_file")
     moveit_launch_file = LaunchConfiguration("moveit_launch_file")
@@ -55,7 +54,6 @@ def launch_setup(context, *args, **kwargs):
         launch_arguments={
             "ur_type": ur_type,
             "safety_limits": safety_limits,
-            "runtime_config_package": runtime_config_package,
             "controllers_file": controllers_file,
             "description_file": description_file,
             "tf_prefix": prefix,
@@ -101,17 +99,11 @@ def generate_launch_description():
     # General arguments
     declared_arguments.append(
         DeclareLaunchArgument(
-            "runtime_config_package",
-            default_value="ur_simulation_gz",
-            description='Package with the controller\'s configuration in "config" folder. '
-            "Usually the argument is not set, it enables use of a custom setup.",
-        )
-    )
-    declared_arguments.append(
-        DeclareLaunchArgument(
             "controllers_file",
-            default_value="ur_controllers.yaml",
-            description="YAML file with the controllers configuration.",
+            default_value=PathJoinSubstitution(
+                [FindPackageShare("ur_simulation_gz"), "config", "ur_controllers.yaml"]
+            ),
+            description="Absolute path to YAML file with the controllers configuration.",
         )
     )
     declared_arguments.append(


### PR DESCRIPTION
This PR finishes removing the relative path definition for launch arguments: as already done in [#32](https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/pull/32), here the previous relative path definition of the controllers file is substituted with a nicer absolute path one. 