### PR TITLE
Add world_file as launch argument

### DIFF
--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -64,6 +64,7 @@ def launch_setup(context, *args, **kwargs):
     launch_rviz = LaunchConfiguration("launch_rviz")
     rviz_config_file = LaunchConfiguration("rviz_config_file")
     gazebo_gui = LaunchConfiguration("gazebo_gui")
+    world_file = LaunchConfiguration("world_file")
 
     robot_description_content = Command(
         [
@@ -161,7 +162,9 @@ def launch_setup(context, *args, **kwargs):
         ),
         launch_arguments={
             "gz_args": IfElseSubstitution(
-                gazebo_gui, if_value=" -r -v 4 empty.sdf", else_value=" -s -r -v 4 empty.sdf"
+                gazebo_gui,
+                if_value=[" -r -v 4 ", world_file],
+                else_value=[" -s -r -v 4 ", world_file],
             )
         }.items(),
     )
@@ -268,6 +271,13 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "gazebo_gui", default_value="true", description="Start gazebo with GUI?"
+        )
+    )
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "world_file",
+            default_value="empty.sdf",
+            description="Gazebo world file (absolute path) containing custom world.",
         )
     )
 

--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -277,7 +277,7 @@ def generate_launch_description():
         DeclareLaunchArgument(
             "world_file",
             default_value="empty.sdf",
-            description="Gazebo world file (absolute path) containing custom world.",
+            description="Gazebo world file (absolute path or filename from the gazebosim worlds collection) containing a custom world.",
         )
     )
 


### PR DESCRIPTION
This PR adds the possibility of using a custom world in Gazebo instead of an empty one. A possible usage for this would be to add graspable objects for the arm to interact with. 