### PR TITLE
Adding world_file as launch argument

### DIFF
--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -58,6 +58,7 @@ def launch_setup(context, *args, **kwargs):
     start_joint_controller = LaunchConfiguration("start_joint_controller")
     initial_joint_controller = LaunchConfiguration("initial_joint_controller")
     launch_rviz = LaunchConfiguration("launch_rviz")
+    world_file = LaunchConfiguration("world_file")
 
     initial_joint_controllers = PathJoinSubstitution(
         [FindPackageShare(runtime_config_package), "config", controllers_file]
@@ -165,7 +166,7 @@ def launch_setup(context, *args, **kwargs):
         PythonLaunchDescriptionSource(
             [FindPackageShare("ros_gz_sim"), "/launch/gz_sim.launch.py"]
         ),
-        launch_arguments={"gz_args": " -r -v 4 empty.sdf"}.items(),
+        launch_arguments={"gz_args": [" -r -v 4 ", world_file]}.items(),
     )
 
     nodes_to_start = [
@@ -270,5 +271,11 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument("launch_rviz", default_value="true", description="Launch RViz?")
     )
-
+    declared_arguments.append(
+        DeclareLaunchArgument(
+            "world_file",
+            default_value="empty.sdf",
+            description="Gazebo world file (absolute path or filename from the gazebosim worlds collection) containing a custom world.",
+        )
+    )
     return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])


### PR DESCRIPTION
This PR backports two useful launch_arguments to iron: 

- `gazebo_gui` &rarr; for choosing if the gazebo gui should start or not
- `world_file` &rarr; for indicating a custom world file for the simulation