### PR TITLE
remove not-released files

### DIFF
--- a/.github/workflows/rolling-binary-main.yml
+++ b/.github/workflows/rolling-binary-main.yml
@@ -19,4 +19,3 @@ jobs:
       ros_distro: rolling
       ros_repo: main
       ref_for_scheduled_build: ros2
-      upstream_workspace: ur_simulation_gz-not-released.rolling.repos

--- a/.github/workflows/rolling-binary-testing.yml
+++ b/.github/workflows/rolling-binary-testing.yml
@@ -19,4 +19,3 @@ jobs:
       ros_distro: rolling
       ros_repo: testing
       ref_for_scheduled_build: ros2
-      upstream_workspace: ur_simulation_gz-not-released.rolling.repos

--- a/ur_simulation_gz-not-released.rolling.repos
+++ b/ur_simulation_gz-not-released.rolling.repos
@@ -1,5 +1,0 @@
-repositories:
-  gz_ros2_control:
-    type: git
-    url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master


### PR DESCRIPTION
Since gz_ros2_control is now released, we can delete the not-released repos files.