### PR TITLE
Fix CI: binary and semi-binary

### DIFF
--- a/ur_simulation_gz.jazzy.repos
+++ b/ur_simulation_gz.jazzy.repos
@@ -2,7 +2,7 @@ repositories:
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: jazzy
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2.git

--- a/ur_simulation_gz.rolling.repos
+++ b/ur_simulation_gz.rolling.repos
@@ -2,7 +2,7 @@ repositories:
   gz_ros2_control:
     type: git
     url: https://github.com/ros-controls/gz_ros2_control.git
-    version: master
+    version: rolling
   moveit2:
     type: git
     url: https://github.com/ros-planning/moveit2.git


### PR DESCRIPTION
In the last PR for the `ros2` branch the CI was failing because `gz_ros2_control` moved from using a single `master` branch to have separate branches for [rolling](https://github.com/ros-controls/gz_ros2_control) and [jazzy](https://github.com/ros-controls/gz_ros2_control/tree/jazzy).  This PR tries to fix that by updating the repos files.