### PR TITLE
Use sjtc and generate /clock topic

### DIFF
--- a/ur_simulation_gz/config/ur_controllers.yaml
+++ b/ur_simulation_gz/config/ur_controllers.yaml
@@ -88,6 +88,7 @@ scaled_joint_trajectory_controller:
     state_interfaces:
       - position
       - velocity
+    speed_scaling_interface_name: ""
     state_publish_rate: 100.0
     action_monitor_rate: 20.0
     allow_partial_joints_goal: false

--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -243,7 +243,7 @@ def generate_launch_description():
     declared_arguments.append(
         DeclareLaunchArgument(
             "initial_joint_controller",
-            default_value="joint_trajectory_controller",
+            default_value="scaled_joint_trajectory_controller",
             description="Robot controller to start.",
         )
     )

--- a/ur_simulation_gz/launch/ur_sim_control.launch.py
+++ b/ur_simulation_gz/launch/ur_sim_control.launch.py
@@ -169,6 +169,16 @@ def launch_setup(context, *args, **kwargs):
         }.items(),
     )
 
+    # Make the /clock topic available in ROS
+    gz_sim_bridge = Node(
+        package="ros_gz_bridge",
+        executable="parameter_bridge",
+        arguments=[
+            "/clock@rosgraph_msgs/msg/Clock[gz.msgs.Clock",
+        ],
+        output="screen",
+    )
+
     nodes_to_start = [
         robot_state_publisher_node,
         joint_state_broadcaster_spawner,
@@ -177,6 +187,7 @@ def launch_setup(context, *args, **kwargs):
         initial_joint_controller_spawner_started,
         gz_spawn_entity,
         gz_launch_description,
+        gz_sim_bridge,
     ]
 
     return nodes_to_start

--- a/ur_simulation_gz/package.xml
+++ b/ur_simulation_gz/package.xml
@@ -17,11 +17,12 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>gz_ros2_control</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>launch</exec_depend>
   <exec_depend>launch_ros</exec_depend>
+  <exec_depend>ros_gz_bridge</exec_depend>
+  <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>rviz2</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_moveit_config</exec_depend>

--- a/ur_simulation_gz/package.xml
+++ b/ur_simulation_gz/package.xml
@@ -24,6 +24,7 @@
   <exec_depend>ros_gz_bridge</exec_depend>
   <exec_depend>ros_gz_sim</exec_depend>
   <exec_depend>rviz2</exec_depend>
+  <exec_depend>ur_controllers</exec_depend>
   <exec_depend>ur_description</exec_depend>
   <exec_depend>ur_moveit_config</exec_depend>
   <exec_depend>urdf</exec_depend>

--- a/ur_simulation_gz/test/test_gz.py
+++ b/ur_simulation_gz/test/test_gz.py
@@ -112,7 +112,7 @@ class GazeboTest(unittest.TestCase):
     def init_robot(self):
         self._follow_joint_trajectory = ActionInterface(
             self.node,
-            "/joint_trajectory_controller/follow_joint_trajectory",
+            "/scaled_joint_trajectory_controller/follow_joint_trajectory",
             FollowJointTrajectory,
         )
         # TODO: Replace this timeout with a proper check whether the robot is initialized


### PR DESCRIPTION
With https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1145 it is possible to use use the scaled JTC on systems that don't have the scaling state interface available. This way, we won't have to change the controller in the MoveIt configuration anymore in order to use the example MoveIt package with GZ Sim.

Draft until https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver/pull/1145 is merged.