### PR TITLE
Add a ground plane to the gz URDF

### DIFF
--- a/ur_simulation_gz/urdf/ur_gz.urdf.xacro
+++ b/ur_simulation_gz/urdf/ur_gz.urdf.xacro
@@ -27,6 +27,30 @@
   <!-- create link fixed to the "world" -->
   <link name="world" />
 
+  <link name="ground_plane">
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="5 5 0"/>
+      </geometry>
+      <material name="ground_white">
+        <color rgba="1 1 1 0.5"/>
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="5 5 0"/>
+      </geometry>
+    </collision>
+  </link>
+
+  <joint name="ground_plane_joint" type="fixed">
+    <origin xyz="0 0 -0.01" rpy="0 0 0"/>
+    <parent link="world"/>
+    <child link="ground_plane"/>
+  </joint>
+
   <!-- arm -->
   <xacro:ur_robot
     name="$(arg name)"


### PR DESCRIPTION
Since for Gazebo the ground plane is a relevant physical obstacle, the robot description should reflect that, so that planners will only consider solutions not crossing the ground plane.