### PR TITLE
Fix semi-binary builds

### DIFF
--- a/ur_simulation_gz.jazzy.repos
+++ b/ur_simulation_gz.jazzy.repos
@@ -31,3 +31,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: rolling
+  Universal_Robots_ROS2_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: main

--- a/ur_simulation_gz.jazzy.repos
+++ b/ur_simulation_gz.jazzy.repos
@@ -11,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_msgs.git
     version: ros2
+  srdfdom:
+    type: git
+    url: https://github.com/moveit/srdfdom.git
+    version: ros2
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git

--- a/ur_simulation_gz.rolling.repos
+++ b/ur_simulation_gz.rolling.repos
@@ -31,3 +31,7 @@ repositories:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Description.git
     version: rolling
+  Universal_Robots_ROS2_Driver:
+    type: git
+    url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
+    version: main

--- a/ur_simulation_gz.rolling.repos
+++ b/ur_simulation_gz.rolling.repos
@@ -11,6 +11,10 @@ repositories:
     type: git
     url: https://github.com/ros-planning/moveit_msgs.git
     version: ros2
+  srdfdom:
+    type: git
+    url: https://github.com/moveit/srdfdom.git
+    version: ros2
   ros2_control:
     type: git
     url: https://github.com/ros-controls/ros2_control.git


### PR DESCRIPTION
As our semi binary builds are currently failing with linker errors on SRDFDOM I assume using that as part of the upstream workspace should help.