### PR TITLE
Expose ros namespace for gazebo sim ros2 control plugin as an argument

### DIFF
--- a/ur_simulation_gz/urdf/ur_gz.urdf.xacro
+++ b/ur_simulation_gz/urdf/ur_gz.urdf.xacro
@@ -23,6 +23,7 @@
   <xacro:arg name="safety_k_position" default="20"/>
 
   <xacro:arg name="simulation_controllers" default="" />
+  <xacro:arg name="ros_namespace" default="" />
 
   <!-- create link fixed to the "world" -->
   <link name="world" />
@@ -73,6 +74,9 @@
   <gazebo>
     <plugin filename="gz_ros2_control-system" name="gz_ros2_control::GazeboSimROS2ControlPlugin">
       <parameters>$(arg simulation_controllers)</parameters>
+      <ros>
+        <namespace>$(arg ros_namespace)</namespace>
+      </ros>
     </plugin>
   </gazebo>
 


### PR DESCRIPTION
Allow multiple robots to be loaded in simulation using separate controller managers, by exposing the `<ros><namespace>` parameter as a xacro argument.

Without this, loading two robots in gazebo using xacro causes errors in the gazebo sim ros2 control plugin.