### PR TITLE
Remove FTS broadcaster from list of controllers

### DIFF
--- a/ur_simulation_gz/config/ur_controllers.yaml
+++ b/ur_simulation_gz/config/ur_controllers.yaml
@@ -11,9 +11,6 @@ controller_manager:
     speed_scaling_state_broadcaster:
       type: ur_controllers/SpeedScalingStateBroadcaster
 
-    force_torque_sensor_broadcaster:
-      type: ur_controllers/ForceTorqueStateBroadcaster
-
     joint_trajectory_controller:
       type: joint_trajectory_controller/JointTrajectoryController
 
@@ -30,21 +27,6 @@ controller_manager:
 speed_scaling_state_broadcaster:
   ros__parameters:
     state_publish_rate: 100.0
-
-
-force_torque_sensor_broadcaster:
-  ros__parameters:
-    sensor_name: tcp_fts_sensor
-    state_interface_names:
-      - force.x
-      - force.y
-      - force.z
-      - torque.x
-      - torque.y
-      - torque.z
-    frame_id: tool0
-    topic_name: ft_data
-
 
 joint_trajectory_controller:
   ros__parameters:


### PR DESCRIPTION
The broadcaster isn't used in this package, anyway, as this doesn't exist in Gazebo (to my knowledge).

The broadcaster entry itself was wrong anyway, since the broadcaster got moved to ros2_controllers a long time ago.

Closes #94 