### PR TITLE
Install ros-core in CI

### DIFF
--- a/.github/workflows/reusable_ici.yml
+++ b/.github/workflows/reusable_ici.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: 'ros-industrial/industrial_ci@master'
         env:
           UPSTREAM_WORKSPACE: ${{ inputs.upstream_workspace }}
+          ADDITIONAL_DEBS: ros-${{ inputs.ros_distro }}-ros-core
           ROS_DISTRO: ${{ inputs.ros_distro }}
           ROS_REPO: ${{ inputs.ros_repo }}
           CMAKE_ARGS: -DUR_SIM_INTEGRATION_TESTS=ON


### PR DESCRIPTION
There is ros2pkg missing as a transitive dependency. It is used by an upstream package but isn't declared. It is so basic, that probably nobody ever noticed. This PR suggests installing ros-core in the test container as it is fair to assume that this is installed everywhere. (it is a dependency of all base meta installation  packages)