### PR TITLE
doc: Add section label

### DIFF
--- a/ur_simulation_gz/doc/index.rst
+++ b/ur_simulation_gz/doc/index.rst
@@ -1,5 +1,7 @@
 :github_url: https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/blob/ros2/ur_simulation_gz/doc/index.rst
 
+.. _ur_simulation_gz:
+
 ur_simulation_gz
 ================
 


### PR DESCRIPTION
The section lable is used in the driver usage docs, but has never been created here. This PR fixes that.