### PR TITLE
Fix driver branch in kilted.repos file

### DIFF
--- a/ur_simulation_gz.kilted.repos
+++ b/ur_simulation_gz.kilted.repos
@@ -30,4 +30,4 @@ repositories:
   Universal_Robots_ROS2_Driver:
     type: git
     url: https://github.com/UniversalRobots/Universal_Robots_ROS2_Driver.git
-    version: main
+    version: kilted


### PR DESCRIPTION
The driver branched out for kilted. Using the main branch fails, due to the removed SJTC (see also #131).