### PR TITLE
Branch kilted (and jazzy) to own branch

### DIFF
--- a/.github/workflows/jazzy-binary-main.yml
+++ b/.github/workflows/jazzy-binary-main.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/jazzy-semi-binary-main.yml
+++ b/.github/workflows/jazzy-semi-binary-main.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted
       upstream_workspace: ur_simulation_gz.jazzy.repos

--- a/.github/workflows/jazzy-semi-binary-testing.yml
+++ b/.github/workflows/jazzy-semi-binary-testing.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted
       upstream_workspace: ur_simulation_gz.jazzy.repos

--- a/.github/workflows/kilted-binary-main.yml
+++ b/.github/workflows/kilted-binary-main.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: main
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-binary-testing.yml
+++ b/.github/workflows/kilted-binary-testing.yml
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: testing
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted

--- a/.github/workflows/kilted-semi-binary-main.yml
+++ b/.github/workflows/kilted-semi-binary-main.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: main
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted
       upstream_workspace: ur_simulation_gz.kilted.repos

--- a/.github/workflows/kilted-semi-binary-testing.yml
+++ b/.github/workflows/kilted-semi-binary-testing.yml
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: testing
-      ref_for_scheduled_build: ros2
+      ref_for_scheduled_build: kilted
       upstream_workspace: ur_simulation_gz.kilted.repos

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Example files and configurations for Gazebo simulation of Universal Robots' mani
   <tr>
     <th>Branch</th>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/humble">humble</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
   </tr>
   <tr>

--- a/ci_status.md
+++ b/ci_status.md
@@ -14,7 +14,8 @@ upstream changes some pipelines might turn red temporarily which can be expected
   <tr>
     <th>Branch</th>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/humble">humble</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
   </tr>
   <tr>


### PR DESCRIPTION
As written in #131 we have to branch out for the upcoming changes. Therefore, I created a `kilted` branch used for Kilted and Jazzy. This PR updates the package in order to point to the correct branches where it matters.