### PR TITLE
Prepare renaming kilted to jazzy

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -10,13 +10,13 @@ pull_request_rules:
         labels:
           - humble
 
-  - name: Backport to iron branch
+  - name: Backport to jazzy branch
     conditions:
       - base=ros2
-      - label=backport-iron
+      - label=backport-jazzy
     actions:
       backport:
         branches:
-          - iron
+          - jazzy
         labels:
-          - iron
+          - jazzy

--- a/.github/workflows/jazzy-binary-main.yml
+++ b/.github/workflows/jazzy-binary-main.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy

--- a/.github/workflows/jazzy-binary-testing.yml
+++ b/.github/workflows/jazzy-binary-testing.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy

--- a/.github/workflows/jazzy-semi-binary-main.yml
+++ b/.github/workflows/jazzy-semi-binary-main.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: main
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy
       upstream_workspace: ur_simulation_gz.jazzy.repos

--- a/.github/workflows/jazzy-semi-binary-testing.yml
+++ b/.github/workflows/jazzy-semi-binary-testing.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: jazzy
       ros_repo: testing
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy
       upstream_workspace: ur_simulation_gz.jazzy.repos

--- a/.github/workflows/kilted-binary-main.yml
+++ b/.github/workflows/kilted-binary-main.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: main
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy

--- a/.github/workflows/kilted-binary-testing.yml
+++ b/.github/workflows/kilted-binary-testing.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,4 +16,4 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: testing
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy

--- a/.github/workflows/kilted-semi-binary-main.yml
+++ b/.github/workflows/kilted-semi-binary-main.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: main
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy
       upstream_workspace: ur_simulation_gz.kilted.repos

--- a/.github/workflows/kilted-semi-binary-testing.yml
+++ b/.github/workflows/kilted-semi-binary-testing.yml
@@ -3,10 +3,10 @@ on:
   workflow_dispatch:
   pull_request:
     branches:
-      - kilted
+      - jazzy
   push:
     branches:
-      - kilted
+      - jazzy
   schedule:
     - cron: '13 4 * * *'
 
@@ -16,5 +16,5 @@ jobs:
     with:
       ros_distro: kilted
       ros_repo: testing
-      ref_for_scheduled_build: kilted
+      ref_for_scheduled_build: jazzy
       upstream_workspace: ur_simulation_gz.kilted.repos

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Example files and configurations for Gazebo simulation of Universal Robots' mani
   <tr>
     <th>Branch</th>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/humble">humble</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/jazzy">jazzy</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/jazzy">jazzy</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
   </tr>

--- a/ci_status.md
+++ b/ci_status.md
@@ -15,8 +15,8 @@ upstream changes some pipelines might turn red temporarily which can be expected
   <tr>
     <th>Branch</th>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/humble">humble</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
-    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/kilted">kilted</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/jazzy">jazzy</a></td>
+    <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/jazzy">jazzy</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
     <td><a href="https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/tree/ros2">ros2</a></td>
   </tr>


### PR DESCRIPTION
I want to propose this mainly because Kilted will become EOL much sooner (December 2026) than Jazzy (May 2029).
Since we haven't made any binary release to jazzy / kilted since branching off for lyrical, I would like to change this now before having to change the branch in rosdistro twice.

As mentioned in https://github.com/UniversalRobots/Universal_Robots_ROS2_GZ_Simulation/issues/134#issuecomment-5058743810