### PR TITLE
Increase minimum CMake version to 3.28

### DIFF
--- a/ur_simulation_gz/CMakeLists.txt
+++ b/ur_simulation_gz/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.28)
 project(ur_simulation_gz)
 
 find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
Support for CMake < 3.10 will be dropped in a future CMake version. This branch targets lyrical upwards, where the minimum version on the supported platforms is 3.28

See https://docs.ros.org/en/lyrical/Releases/lyrical/supported-platforms.html for the supported platforms